### PR TITLE
Zusaetzliche Freigabe "predictionentry.register" in access.xml

### DIFF
--- a/administrator/components/com_joomleague/access.xml
+++ b/administrator/components/com_joomleague/access.xml
@@ -96,6 +96,7 @@
     <action name="predictiongame.unpublish" title="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_UNPUBLISH" description="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_UNPUBLISH_DESC" />
     <action name="predictiongame.publish" title="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_PUBLISH" description="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_PUBLISH_DESC" />
     <action name="predictiongame.register" title="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_REGISTER" description="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_REGISTER_DESC" />
+    <action name="predictionentry.register" title="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_REGISTER" description="COM_JOOMLEAGUE_SETTINGS_PRED_ACCESS_REGISTER_DESC" />
     
     <!-- association-->
 		<action name="association.saveorder" title="COM_JOOMLEAGUE_SETTINGS_ASSOC_ACCESS_SAVEORDER" description="COM_JOOMLEAGUE_SETTINGS_PRED_ASSOC_ACCESS_SAVEORDER_DESC" />


### PR DESCRIPTION
Löst http://www.fussballineuropa.de/index.php?option=com_kunena&view=category&catid=242&id=4323&Itemid=1167&lang=de
#10495
